### PR TITLE
A possible fix for reporting connection failures to calling code

### DIFF
--- a/SungrowModbusTcpClient/SungrowModbusTcpClient.py
+++ b/SungrowModbusTcpClient/SungrowModbusTcpClient.py
@@ -48,9 +48,14 @@ class SungrowModbusTcpClient(ModbusTcpClient):
         self.close()
         result = ModbusTcpClient.connect(self)
         if not result:
-           self._restore()
+            self._restore()
         else:
-           self._getkey()
+            self._getkey()
+            if self._key is not None:
+               # We now have the encryption key stored and a second
+               # connect will likely succeed.
+               self.close()
+               result = ModbusTcpClient.connect(self)
         return result
 
     def close(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="SungrowModbusTcpClient",
-    version="0.1.2",
+    version="0.1.3",
     author="Roberto Panerai Velloso",
     author_email="rvelloso@gmail.com",
     description="A ModbusTcpClient wrapper for talking to Sungrow solar inverters",


### PR DESCRIPTION
This change attempts a reconnect during the initial connection attempt if the initial connection failed and the interface was successful in calculating the session key for a second attempt.

There's some analysis of the issue here: https://github.com/tjhowse/modbus4mqtt/issues/13