### PR TITLE
Switch from PyCrypto to PyCryptodome

### DIFF
--- a/SungrowModbusTcpClient/SungrowModbusTcpClient.py
+++ b/SungrowModbusTcpClient/SungrowModbusTcpClient.py
@@ -1,5 +1,5 @@
 from pymodbus.client.sync import ModbusTcpClient
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 from datetime import date
 
 PRIV_KEY = b'Grow#0*2Sun68CbE'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="SungrowModbusTcpClient",
-    version="0.1.5",
+    version="0.1.6",
     author="Roberto Panerai Velloso",
     author_email="rvelloso@gmail.com",
     description="A ModbusTcpClient wrapper for talking to Sungrow solar inverters",
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'pymodbus>=2.3.0',
-        'pycrypto>=2.6.1',
+        'pycryptodomex>=3.11.0',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
PyCrypto is unmaintained and incompatible with Python 3.10, causing [issues](https://github.com/tjhowse/modbus4mqtt/issues/37).

This PR addresses #6 by switching to a maintained fork of PyCrypto: PyCryptodome. I'm using the PyCryptodomex package, by the same author, as it does not attempt a namespace collision on the "Crypto" module, instead defining "Cryptodome".

Also bumped the version number.