### PR TITLE
Handle breaking changes in pymodbus 3.0

### DIFF
--- a/SungrowModbusTcpClient/SungrowModbusTcpClient.py
+++ b/SungrowModbusTcpClient/SungrowModbusTcpClient.py
@@ -1,9 +1,9 @@
 try:
-    # Pymodbus < 3.0
-    from pymodbus.client.sync import ModbusTcpClient
-except ImportError:
     # Pymodbus >= 3.0
     from pymodbus.client import ModbusTcpClient
+except ImportError:
+    # Pymodbus < 3.0
+    from pymodbus.client.sync import ModbusTcpClient
 from Cryptodome.Cipher import AES
 from datetime import date
 

--- a/SungrowModbusTcpClient/SungrowModbusTcpClient.py
+++ b/SungrowModbusTcpClient/SungrowModbusTcpClient.py
@@ -1,4 +1,9 @@
-from pymodbus.client.sync import ModbusTcpClient
+try:
+    # Pymodbus < 3.0
+    from pymodbus.client.sync import ModbusTcpClient
+except ImportError:
+    # Pymodbus >= 3.0
+    from pymodbus.client import ModbusTcpClient
 from Cryptodome.Cipher import AES
 from datetime import date
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="SungrowModbusTcpClient",
-    version="0.1.6",
+    version="0.1.7",
     author="Roberto Panerai Velloso",
     author_email="rvelloso@gmail.com",
     description="A ModbusTcpClient wrapper for talking to Sungrow solar inverters",


### PR DESCRIPTION
pymodbus moved some internals around that breaks both modbus4mqtt and SungrowModbusTcpClient. This PR tries to import ModbusTcpClient from the new path, and then the old path if the new one fails.